### PR TITLE
Refactor proposal

### DIFF
--- a/src/fanout_util.rs
+++ b/src/fanout_util.rs
@@ -1,0 +1,30 @@
+use fastly::http::StatusCode;
+use fastly::Response;
+
+/// Returns a GRIP response to initialize a stream
+///
+/// When Compute@Edge receives a non-WebSocket request (i.e. normal HTTP) and wants
+/// to make it long lived (longpoll or SSE), we call upgrade_websocket on it, and
+/// Fanout will then forward that request to the nominated backend.  In this app,
+/// that backend is this same Compute@Edge service, where we then need to respond
+/// with some Grip headers to tell Fanout to hold the connection for streaming.
+/// This function constructs such a response.
+pub fn grip_response(ctype: &str, ghold: &str, chan: &str) -> Response {
+    Response::from_status(StatusCode::OK)
+        .with_header("Content-Type", ctype)
+        .with_header("Grip-Hold", ghold)
+        .with_header("Grip-Channel", chan)
+        .with_body("")
+}
+
+/// Returns a WebSocket-over-HTTP formatted TEXT message
+pub fn ws_text(msg: &str) -> Vec<u8> {
+    format!("TEXT {:02x}\r\n{}\r\n", msg.len(), msg)
+        .as_bytes()
+        .to_vec()
+}
+
+// Returns a channel-subscription command in a WebSocket-over-HTTP format
+pub fn ws_sub(ch: &str) -> Vec<u8> {
+    ws_text(format!("c:{{\"type\":\"subscribe\",\"channel\":\"{}\"}}", ch).as_str())
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -2,109 +2,60 @@ use fastly::experimental::RequestUpgradeWebsocket;
 use fastly::http::StatusCode;
 use fastly::{Error, Request, Response};
 
-fn handle_root(_req: Request) -> Response {
-    Response::from_status(StatusCode::OK)
-        .with_header("Content-Type", "text/plain")
-        .with_body("Hello from the Fanout test handler!\n")
-}
+mod fanout_util;
 
-fn handle_long_poll(_req: Request) -> Response {
-    Response::from_status(StatusCode::OK)
-        .with_header("Content-Type", "text/plain")
-        .with_header("Grip-Hold", "response")
-        .with_header("Grip-Channel", "test")
-        .with_body("no data\n")
-}
-
-fn handle_stream(_req: Request) -> Response {
-    Response::from_status(StatusCode::OK)
-        .with_header("Content-Type", "text/plain")
-        .with_header("Grip-Hold", "stream")
-        .with_header("Grip-Channel", "test")
-        .with_body("stream open\n")
-}
-
-fn handle_sse(_req: Request) -> Response {
-    Response::from_status(StatusCode::OK)
-        .with_header("Content-Type", "text/event-stream")
-        .with_header("Grip-Hold", "stream")
-        .with_header("Grip-Channel", "test")
-        .with_body("event: message\ndata: stream open\n\n")
-}
-
-fn handle_ws(mut req: Request) -> Response {
-    let content_type = match req.get_header_str("Content-Type") {
-        Some(s) => s,
-        None => {
-            return Response::from_status(StatusCode::BAD_REQUEST).with_body("Need Content-Type.\n")
-        }
-    };
-
-    if content_type != "application/websocket-events" {
+fn handle_fanout_ws(mut req: Request, chan: &str) -> Response {
+    if req.get_header_str("Content-Type") != Some("application/websocket-events") {
         return Response::from_status(StatusCode::BAD_REQUEST)
             .with_body("Not a WebSocket-over-HTTP request.\n");
     }
 
-    let body = req.take_body().into_bytes();
-
-    let mut sub = false;
-
-    if body.len() >= 6 && &body[..6] == b"OPEN\r\n" {
-        sub = true;
-    }
-
-    // echo
-    let mut out_body = body.clone();
-
-    if sub {
-        let msg = "c:{\"type\":\"subscribe\",\"channel\":\"test\"}";
-        out_body.extend(format!("TEXT {:02x}\r\n{}\r\n", msg.len(), msg).as_bytes());
-    }
+    let req_body = req.take_body().into_bytes();
+    let mut resp_body: Vec<u8> = [].to_vec();
 
     let mut resp = Response::from_status(StatusCode::OK)
         .with_header("Content-Type", "application/websocket-events");
 
-    if sub {
+    if req_body.starts_with(b"OPEN\r\n") {
         resp.set_header("Sec-WebSocket-Extensions", "grip; message-prefix=\"\"");
+        resp_body.extend("OPEN\r\n".as_bytes());
+        resp_body.extend(fanout_util::ws_sub(chan));
+    } else if req_body.starts_with(b"TEXT ") {
+        resp_body.extend(fanout_util::ws_text(
+            format!("You said: {}", std::str::from_utf8(&req_body).unwrap_or("")).as_str(),
+        ));
     }
 
-    resp.set_body(out_body);
-
+    resp.set_body(resp_body);
     resp
 }
 
-fn handle(req: Request) -> Result<Response, Error> {
-    let path = req.get_url().path();
-
-    match path {
-        "/" => Ok(handle_root(req)),
-        "/response" => Ok(handle_long_poll(req)),
-        "/stream" => Ok(handle_stream(req)),
-        "/sse" => Ok(handle_sse(req)),
-        "/ws" => Ok(handle_ws(req)),
-        _ => Ok(Response::from_status(StatusCode::NOT_FOUND).with_body("no such test resource\n")),
+fn handle_fanout(req: Request, chan: &str) -> Response {
+    match req.get_url().path() {
+        "/stream/long-poll" => fanout_util::grip_response("text/plain", "response", chan),
+        "/stream/plain" => fanout_util::grip_response("text/plain", "stream", chan),
+        "/stream/sse" => fanout_util::grip_response("text/event-stream", "stream", chan),
+        "/stream/websocket" => handle_fanout_ws(req, chan),
+        _ => Response::from_status(StatusCode::BAD_REQUEST).with_body("Invalid Fanout request\n"),
     }
 }
 
 fn main() -> Result<(), Error> {
-    let mut req = Request::from_client();
+    let req = Request::from_client();
 
-    if !(req.get_header_str("Grip-Sig").is_some()) {
-        // if the request didn't come through Fanout,
-        // tell the subsystem that the request should be routed
-        // through Fanout first
-
-        if req.get_body_mut().read_chunks(1).next().is_some() {
-            return Ok(Response::from_status(StatusCode::BAD_REQUEST)
-                .with_body("Request body must be empty.\n")
-                .send_to_client());
-        }
-
-        // despite the name, this function works for both http requests and
-        // websockets. we plan to update the SDK to make this more intuitive
-        Ok(req.upgrade_websocket("self")?)
-    } else {
-        // if the request came from Fanout, process it with handle()
-        Ok(handle(req)?.send_to_client())
+    // Request is a stream request - from client, or from fanout
+    if req.get_path().starts_with("/stream/") {
+        return Ok(if req.get_header_str("Grip-Sig").is_some() {
+            // Request is from Fanout
+            handle_fanout(req, "test").send_to_client()
+        } else {
+            // Not from fanout, hand it off to Fanout to manage
+            req.upgrade_websocket("self")?
+        });
     }
+
+    // Forward all non-stream requests to the primary backend
+    let be_resp = req.send("primary_backend");
+
+    Ok(be_resp?.send_to_client())
 }


### PR DESCRIPTION
Playing around with the starter kit in order to write Fanout docs, I found  myself refactoring it a bit and thought I'd see if we want to adopt this.  Main changes are:

* Abstract out some self contained functions to format messages for Grip and WSoHTTP
* Use a path match in main() because we don't want to encourage all requests to go through Fanout
* Add a primary backend that's separate from the loopback 'self' backend (acknowledging that most customers will have a backend that's not the service itself)
* Make the channel somewhat more configurable