### PR TITLE
Populate scripts.build

### DIFF
--- a/fastly.toml
+++ b/fastly.toml
@@ -3,3 +3,6 @@ description = "Implements Fanout handlers for WebSockets, SSE, etc."
 language = "rust"
 manifest_version = 2
 name = "Push messaging using Fanout"
+
+[scripts]
+  build = "cargo build --bin fastly-compute-project --release --target wasm32-wasi --color always"


### PR DESCRIPTION
For backwards compatibility Fastly CLI implies a `scripts.build` based on the language, but it's best to provide one in the `fastly.toml`.