### PR TITLE
Add starter kit redirect file for upcoming CLI update

### DIFF
--- a/.starter-kit-id
+++ b/.starter-kit-id
@@ -1,0 +1,1 @@
+starter-kit/rust/fanout


### PR DESCRIPTION
Adds the `.starter-kit-id` redirect marker so an upcoming Fastly CLI release can transparently source this kit's content from the new consolidated monorepo (fastly/compute-starter-kits) instead of this standalone repo. File content: `starter-kit/rust/fanout`.